### PR TITLE
Move tools/common back to original

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/3DWCommunity/nnheaders.git
 [submodule "tools/common"]
 	path = tools/common
-	url = https://github.com/3DWCommunity/nx-decomp-tools.git
+	url = https://github.com/open-ead/nx-decomp-tools.git

--- a/tools/config.toml
+++ b/tools/config.toml
@@ -1,6 +1,5 @@
 functions_csv = "data/bf_functions.csv"
 build_target = "bf"
-skip_got_section = true
 
 [decomp_me]
 compiler_name = "clang-8.0.0"


### PR DESCRIPTION
the fix has been merged now, so we can safely continue using the open-ead version of nx-decomp-tools
